### PR TITLE
on sagaHelpers.js "methods" renamed to "listeners" and fixed not…

### DIFF
--- a/src/utils/sagaHelpers.js
+++ b/src/utils/sagaHelpers.js
@@ -1,17 +1,17 @@
+import { fork, call, take } from "redux-saga/effects";
+import { eventChannel } from "redux-saga";
 
-import {fork, call, take} from 'redux-saga/effects';
-import {eventChannel} from 'redux-saga';
+export const takeFirst = (patternOrChannel, saga, ...args) =>
+  fork(function*() {
+    while (true) {
+      const action = yield take(patternOrChannel);
+      yield call(saga, ...args.concat(action));
+    }
+  });
 
-export const takeFirst = (patternOrChannel, saga, ...args) => fork(function * () {
-  while (true) {
-    const action = yield take(patternOrChannel);
-    yield call(saga, ...args.concat(action));
-  }
-});
-
-export const eventEmitterChannel = (emitter, methods, eventName) => {
-  return eventChannel(notifire => {
-    emitter[methods.on](eventName, notifire);
-    return () => emitter[methods.off](eventName, notifire);
+export const eventEmitterChannel = (emitter, listeners, eventName) => {
+  return eventChannel(notifier => {
+    emitter[listeners.on](eventName, notifier);
+    return () => emitter[listeners.off](eventName, notifier);
   });
 };


### PR DESCRIPTION
I think 'listeners' instead of 'methods' will be more appropriate. And 'notifire' has a spelling mistake. It will be 'notifier'. 